### PR TITLE
Allow specifying the version string directly

### DIFF
--- a/chachacha/drivers/kac.py
+++ b/chachacha/drivers/kac.py
@@ -150,8 +150,10 @@ class ChangelogFormat:
             last = str(version.bump_major())
         elif mode == "minor":
             last = str(version.bump_minor())
-        else:
+        elif mode == "patch":
             last = str(version.bump_patch())
+        else:
+            last = mode
 
         entries = current.pop("Unreleased")
 

--- a/tests/test_changelog_cli.py
+++ b/tests/test_changelog_cli.py
@@ -26,7 +26,7 @@ def test_git_provider_missing_param(tmp_path):
         assert result.exit_code == 0, result.output
         result = runner.invoke(main.main, ["added", "a changelog entry string"])
         assert result.exit_code == 0, result.output
-        result = runner.invoke(main.main, ["release", "--major"])
+        result = runner.invoke(main.main, ["release", "major"])
         assert result.exit_code == 0, result.output
 
     changelog = open("CHANGELOG.md").read()
@@ -88,7 +88,7 @@ def test_git_provider(tmp_path):
         assert result.exit_code == 0
         result = runner.invoke(main.main, ["added", "a changelog entry string"])
         assert result.exit_code == 0
-        result = runner.invoke(main.main, ["release", "--major"])
+        result = runner.invoke(main.main, ["release", "major"])
         assert result.exit_code == 0
 
     changelog = open("CHANGELOG.md").read()
@@ -221,7 +221,7 @@ def test_release_major(tmp_path):
     runner.invoke(main.main, ["init"])
 
     runner.invoke(main.main, ["added", "a changelog entry string"])
-    result = runner.invoke(main.main, ["release", "--major"])
+    result = runner.invoke(main.main, ["release", "major"])
     assert result.exit_code == 0
 
     parsed = keepachangelog.to_dict("CHANGELOG.md", show_unreleased=True)
@@ -240,7 +240,7 @@ def test_release_minor(tmp_path):
     runner.invoke(main.main, ["init"])
 
     runner.invoke(main.main, ["added", "a changelog entry string"])
-    result = runner.invoke(main.main, ["release", "--minor"])
+    result = runner.invoke(main.main, ["release", "minor"])
     assert result.exit_code == 0
 
     parsed = keepachangelog.to_dict("CHANGELOG.md", show_unreleased=True)
@@ -260,7 +260,7 @@ def test_release_patch(tmp_path):
     runner.invoke(main.main, ["init"])
 
     runner.invoke(main.main, ["added", "a changelog entry string"])
-    result = runner.invoke(main.main, ["release", "--patch"])
+    result = runner.invoke(main.main, ["release", "patch"])
     assert result.exit_code == 0
 
     parsed = keepachangelog.to_dict("CHANGELOG.md", show_unreleased=True)
@@ -271,6 +271,35 @@ def test_release_patch(tmp_path):
             "version": "0.0.1",
         }
     }
+
+
+def test_release_specfic(tmp_path):
+    os.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main.main, ["init"])
+
+    runner.invoke(main.main, ["added", "a changelog entry string"])
+    result = runner.invoke(main.main, ["release", "2.0.0"])
+    assert result.exit_code == 0, result.stdout
+
+    parsed = keepachangelog.to_dict("CHANGELOG.md", show_unreleased=True)
+    assert parsed == {
+        "2.0.0": {
+            "added": ["- a changelog entry string"],
+            "release_date": datetime.now().isoformat().split("T")[0],
+            "version": "2.0.0",
+        }
+    }
+
+
+def test_release_invalid(tmp_path):
+    os.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main.main, ["init"])
+
+    runner.invoke(main.main, ["added", "a changelog entry string"])
+    result = runner.invoke(main.main, ["release", "invalid"])
+    assert result.exit_code != 0
 
 
 def test_release(tmp_path):

--- a/tests/test_changelog_cli.py
+++ b/tests/test_changelog_cli.py
@@ -285,7 +285,7 @@ def test_release_specfic(tmp_path):
     parsed = keepachangelog.to_dict("CHANGELOG.md", show_unreleased=True)
     assert parsed == {
         "2.0.0": {
-            "added": ["- a changelog entry string"],
+            "added": ["a changelog entry string"],
             "release_date": datetime.now().isoformat().split("T")[0],
             "version": "2.0.0",
         }


### PR DESCRIPTION
This fixes issue #24

It adds a new feature to the `release` command to specify the version string exactly:

```bash
chachacha release 2.4.2
```

This has required a change in functionality of the existing release syntax. Where before it was, e.g.:

```bash
chachacha release --patch
```

it is now

```bash
chachacha release patch
```